### PR TITLE
Fix docs and add frontend instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ OPENAI_API_KEY=your_openai_api_key_here
 ### Basic Example
 
 ```python
-from EricBacktest import CryptoBacktester
+from ericbacktest import CryptoBacktester
 
 # Initialize the backtester
 backtester = CryptoBacktester()
@@ -169,6 +169,32 @@ for trade in backtester.trades[:5]:
     print(trade)
 ```
 
+## Backend API
+
+A lightweight HTTP server is provided in `api_server.py`. After installing the Python dependencies and configuring your `.env` file, start the server with:
+
+```bash
+python api_server.py
+```
+
+The server listens on `http://localhost:8000` by default and exposes endpoints to parse strategies and run backtests.
+
+## Frontend Dashboard
+
+The React frontend lives in `crypto-backtest-frontend/`. It communicates with the backend API.
+
+```bash
+cd crypto-backtest-frontend
+npm install
+# optional: set the API URL if the backend isn't on localhost
+REACT_APP_API_URL=http://localhost:8000 npm start
+```
+
+### Using Them Together
+
+1. Start the backend server.
+2. Run the frontend with `npm start`.
+3. The dashboard will call the backend at the URL specified by `REACT_APP_API_URL`.
 ## Contributing
 
 1. Fork the repository

--- a/crypto-backtest-frontend/README.md
+++ b/crypto-backtest-frontend/README.md
@@ -1,7 +1,40 @@
-# Crypto Backtest Pro - Frontend
+# Crypto Backtest Frontend
 
-A professional cryptocurrency backtesting dashboard built with React, Tailwind CSS, and Recharts.
+This directory contains the React dashboard that interacts with the Python backtesting API.
 
-## Quick Start
+## Prerequisites
 
-1. **Install Dependencies**
+- Node.js 16+ and npm
+
+## Setup
+
+Install the dependencies:
+
+```bash
+npm install
+```
+
+(Optional) create a `.env` file to set the backend URL. The default is `http://localhost:8000`:
+
+```bash
+REACT_APP_API_URL=http://localhost:8000
+```
+
+## Development
+
+Start the development server:
+
+```bash
+npm start
+```
+
+## Production Build
+
+```bash
+npm run build
+```
+
+## Running with the Backend
+
+Make sure the Python API server is running (see the main README). The dashboard will use the URL specified in `REACT_APP_API_URL` to communicate with it.
+


### PR DESCRIPTION
## Summary
- correct Python import in README
- explain how the backend API and React frontend work together
- add a full README in `crypto-backtest-frontend`

## Testing
- `python -m py_compile ericbacktest.py api_server.py setup.py`

------
https://chatgpt.com/codex/tasks/task_e_6849d650b520832aa39d30cba243e545