### PR TITLE
Add devcontainer and codespaces guide

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,11 @@
+{
+  "name": "BacktestDF Dev Container",
+  "image": "mcr.microsoft.com/devcontainers/python:0-3.8",
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "18"
+    }
+  },
+  "forwardPorts": [8000, 3000],
+  "postCreateCommand": "pip install -r requirements.txt && npm install --prefix crypto-backtest-frontend"
+}

--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ PINECONE_API_KEY=your_pinecone_api_key_here
 OPENAI_API_KEY=your_openai_api_key_here
 ```
 
+## GitHub Codespaces
+
+You can run this project in a cloud devcontainer using GitHub Codespaces.
+From the repository page, click **Code** then **Open with Codespaces**.
+The container installs Python and Node dependencies automatically and forwards ports `8000` and `3000`.
+
 ## Usage
 
 ### Basic Example


### PR DESCRIPTION
## Summary
- add GitHub Codespaces section in README
- add `.devcontainer/devcontainer.json` using Python 3.8 and Node 18

## Testing
- `python -m pytest -q`
- `pip install -r requirements.txt` *(fails: Tunnel connection failed 403)*
- `npm install --prefix crypto-backtest-frontend` *(fails: 403 Forbidden)*


------
https://chatgpt.com/codex/tasks/task_e_6849dd0f4874832a9e11c21814869713