### PR TITLE
Improve docs for Codespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ npm install
 REACT_APP_API_URL=http://localhost:8000 npm start
 ```
 
+In a Codespace, the backend URL is the forwarded address for port 8000 shown in the **Ports** tab (for example `https://8000-<your-codespace>.githubpreview.dev`). Assign this value to `REACT_APP_API_URL` before starting the frontend.
 ### Using Them Together
 
 1. Start the backend server.

--- a/crypto-backtest-frontend/README.md
+++ b/crypto-backtest-frontend/README.md
@@ -19,7 +19,13 @@ npm install
 ```bash
 REACT_APP_API_URL=http://localhost:8000
 ```
+### Using in GitHub Codespaces
 
+When the backend runs in a Codespace, port `8000` is forwarded and a unique URL is shown in the **Ports** tab. Copy this address (for example `https://8000-<your-codespace>.githubpreview.dev`) and set `REACT_APP_API_URL` to it when starting the frontend:
+
+```bash
+REACT_APP_API_URL=https://8000-<your-codespace>.githubpreview.dev npm start
+```
 ## Development
 
 Start the development server:


### PR DESCRIPTION
## Summary
- document how to set `REACT_APP_API_URL` when using GitHub Codespaces
- mention the forwarded port in the main README

## Testing
- `python -m py_compile ericbacktest.py api_server.py setup.py`
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6849dd1acf24832a988a5032529139e2